### PR TITLE
feat: Save and Load as JSON

### DIFF
--- a/src/util/serializer.ts
+++ b/src/util/serializer.ts
@@ -1,0 +1,15 @@
+import type { GridState } from '@/components/PixelGrid'
+
+class SerializerDeserializer {
+  getJSONFromGridState(gridState: GridState): string {
+    const jsonData = {
+      present: gridState.present,
+      past: gridState.past,
+      future: gridState.future,
+    }
+
+    return JSON.stringify(jsonData, null, 2)
+  }
+}
+
+export const serializerDeserializer = new SerializerDeserializer()


### PR DESCRIPTION
Resolves #17 

This PR introduces the ability for users to save their entire drawing session to a local JSON file and load it back into the editor at a later time. This feature ensures that users' work is not lost when they close the application.

A key aspect of this implementation is that the entire state, including the undo/redo history (past, present, and future), is preserved.

Implementation Details:
- State Serialization: A new serializer.ts utility was created to handle the conversion of the GridState object into a clean JSON string.
- Reducer Logic: A new LOAD_STATE action was added to the reducer. This action replaces the current grid state with the parsed state from a loaded JSON file, effectively restoring the session.
- UI Components: Added "Save as JSON" (<Save />) and "Load from JSON" (<Upload />) buttons to the main control panel, using standard browser APIs (FileReader, Blob) for file handling.
- Type Safety: The exported GridState type is used to ensure consistency between the component and the serialization utility.

How to Test:
1. Create a drawing on the canvas.
2. Make several more strokes/edits to build up an undo history.
3. Click the "Undo" button a few times.
4. Click the "Save as JSON" button to download the pixel-grid-state.json file.
5. Clear the canvas using the "Reset" button (or refresh the page).
6. Click the "Load from JSON" button and select the file you just saved.

Verification:
1. The canvas should be restored to the exact state it was in when you saved it.
2. Crucially, test that both the "Undo" and "Redo" buttons work correctly, reflecting the saved history.

Video:
[Screencast from 05-10-25 11:12:04 AM IST.webm](https://github.com/user-attachments/assets/6540afd0-f046-43f4-8207-387b5fd22f8d)
