### PR TITLE
feat: add toggle grid lines feature

### DIFF
--- a/src/components/PixelGrid.tsx
+++ b/src/components/PixelGrid.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useReducer, useRef, useState } from 'react'
 import ColorPicker from './ColorPicker'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
+import clsx from 'clsx'
 import {
   AlertDialog,
   AlertDialogTrigger,
@@ -84,6 +85,7 @@ const PixelGrid: React.FC<PixelGridProps> = ({
   cols = GRID_SIZE_DEFAULT,
 }) => {
   const [selectedColor, setSelectedColor] = useState('#000000')
+  const [showGridLines, setShowGridLines] = useState(true)
   const [state, dispatch] = useReducer(gridReducer, {
     past: [],
     present: createEmptyGrid(rows, cols),
@@ -179,6 +181,10 @@ const PixelGrid: React.FC<PixelGridProps> = ({
             <span className="text-gray-700 dark:text-gray-200 text-sm">Dark Mode</span>
             <Switch checked={darkMode} onCheckedChange={setDarkMode} />
           </div>
+          <div className="flex items-center gap-1 ml-auto">
+            <span className="text-gray-700 dark:text-gray-200 text-sm">Show Grid Lines</span>
+            <Switch checked={showGridLines} onCheckedChange={setShowGridLines} />
+          </div>
         </div>
 
         {/* Pixel Grid */}
@@ -189,7 +195,12 @@ const PixelGrid: React.FC<PixelGridProps> = ({
                 <div
                   key={colIndex}
                   onClick={() => handleCellClick(rowIndex, colIndex)}
-                  className="w-6 h-6 border border-gray-300 dark:border-gray-600 cursor-pointer transition-colors duration-200"
+                  className={clsx(
+                    'w-6 h-6 border-gray-300 dark:border-gray-600 cursor-pointer transition-colors duration-200',
+                    {
+                      border: showGridLines,
+                    }
+                  )}
                   style={{ backgroundColor: color }}
                 />
               ))}

--- a/src/components/PixelGrid.tsx
+++ b/src/components/PixelGrid.tsx
@@ -2,10 +2,16 @@ import React, { useEffect, useReducer, useRef, useState } from 'react'
 import ColorPicker from './ColorPicker'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import { Undo2, Redo2, Trash2, Download, ChevronDown } from 'lucide-react'
+import { Undo2, Redo2, Trash2, ChevronDown } from 'lucide-react'
 import SettingsDialog from './SettingsDialog'
 import { exportOptions, type ExportTypes } from '@/util/export'
-import { DropdownMenuContent, DropdownMenuItem, DropdownMenu, DropdownMenuTrigger } from './ui/dropdown-menu'
+import {
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenu,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu'
+import clsx from 'clsx'
 
 interface PixelGridProps {
   rows?: number
@@ -77,6 +83,7 @@ const gridReducer = (state: GridState, action: Action): GridState => {
 const PixelGrid: React.FC<PixelGridProps> = ({ rows = DEFAULT_GRID, cols = DEFAULT_GRID }) => {
   const [selectedColor, setSelectedColor] = useState('#000000')
   const [darkMode, setDarkMode] = useState(() => localStorage.getItem('theme') === 'dark')
+  const [showGridLines, setShowGridLines] = useState(true)
 
   const [gridRows, setGridRows] = useState(DEFAULT_GRID)
   const [gridCols, setGridCols] = useState(DEFAULT_GRID)
@@ -144,7 +151,9 @@ const PixelGrid: React.FC<PixelGridProps> = ({ rows = DEFAULT_GRID, cols = DEFAU
       {/* Pixel Grid */}
       <div
         ref={gridRef}
-        className="gap-[1px] bg-gray-300 dark:bg-gray-700"
+        className={clsx({
+          'bg-gray-300 dark:bg-gray-700 gap-[1px]': showGridLines,
+        })}
         style={{
           display: 'grid',
           gridTemplateColumns: `repeat(${gridCols}, ${cellSize}px)`,
@@ -237,6 +246,8 @@ const PixelGrid: React.FC<PixelGridProps> = ({ rows = DEFAULT_GRID, cols = DEFAU
 
         {/* Settings Alert Dialog */}
         <SettingsDialog
+          showGridLines={showGridLines}
+          toggleGridLines={() => setShowGridLines((p) => !p)}
           darkMode={darkMode}
           toggleDarkMode={() => setDarkMode(!darkMode)}
           gridRows={gridRows}

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -9,11 +9,13 @@ import {
   AlertDialogTrigger,
   AlertDialogFooter,
 } from '@/components/ui/alert-dialog'
-import { Sun, Moon, X as XIcon, Settings } from 'lucide-react'
+import { Sun, Moon, X as XIcon, Settings, EyeClosed, Eye } from 'lucide-react'
 
 interface SettingsDialogProps {
   darkMode: boolean
   toggleDarkMode: () => void
+  showGridLines: boolean
+  toggleGridLines: () => void
   gridRows: number
   setGridRows: (rows: number) => void
   gridCols: number
@@ -27,6 +29,8 @@ interface SettingsDialogProps {
 }
 
 const SettingsDialog: React.FC<SettingsDialogProps> = ({
+  showGridLines,
+  toggleGridLines,
   darkMode,
   toggleDarkMode,
   gridRows,
@@ -90,6 +94,14 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
             <span>Dark Mode</span>
             <Button onClick={toggleDarkMode}>
               {darkMode ? <Sun size={16} /> : <Moon size={16} />}
+            </Button>
+          </div>
+
+          {/* Grid Lines Toggle */}
+          <div className="flex items-center justify-between">
+            <span>Grid Lines</span>
+            <Button onClick={toggleGridLines}>
+              {showGridLines ? <EyeClosed size={16} /> : <Eye size={16} />}
             </Button>
           </div>
 


### PR DESCRIPTION
Fixes #19 

Added a switch to toggle visibility of grid lines

# With Grid Lines
<img width="655" height="636" alt="image" src="https://github.com/user-attachments/assets/fabd921b-2a80-4d1f-9ec7-a118f102a0e6" />

# Without Grid Lines
<img width="571" height="503" alt="image" src="https://github.com/user-attachments/assets/67310bd7-5068-4872-9bc9-d0ec845f2efd" />
